### PR TITLE
Added hacky fix and test

### DIFF
--- a/src/dynamic_bit_vector.h
+++ b/src/dynamic_bit_vector.h
@@ -59,9 +59,10 @@ namespace bsim {
       *((int*) (&(bits[0]))) = val;
     }
 
-    dynamic_bit_vector(const bv_uint8 val) {
-      *((bv_uint8*)(&(bits[0]))) = val;
-    }
+    //dynamic_bit_vector(const int N_, const bv_uint8 val) : N(N_) {
+    //  bits.resize(NUM_BYTES(N));
+    //  *((bv_uint8*)(&(bits[0]))) = val;
+    //}
     
     dynamic_bit_vector(const dynamic_bit_vector& other) {
       bits.resize(other.bits.size());
@@ -119,7 +120,10 @@ namespace bsim {
 
     template<typename ConvType>
     ConvType to_type() const {
-      return *(const_cast<ConvType*>((const ConvType*) (&(bits[0]))));
+      ConvType tmp = *(const_cast<ConvType*>((const ConvType*) (&(bits[0]))));
+      //TODO FIXME I am a sketchy hack.
+      ConvType mask = sizeof(ConvType) > bits.size() ? (1<<N)-1 : -1; 
+      return tmp & mask;
     }
 
     inline bv_uint64 as_native_int32() const {

--- a/test/dynamic_bitvector_tests.cpp
+++ b/test/dynamic_bitvector_tests.cpp
@@ -45,6 +45,12 @@ namespace bsim {
 
       REQUIRE(a.to_type<int>() == 0);
     }
+    SECTION("1 initialization is zero") {
+      int i = 1;
+
+      dynamic_bit_vector a(16,5);
+      REQUIRE(a.to_type<uint64_t>() == 5);
+    }
 
     SECTION("Default initialization is zero") {
       int i = 23;


### PR DESCRIPTION
I was seeing garbage using to_type<T> when sizeof(T) was bigger than N. I have a hacky fix to mask out all bits greater than N.

Let me know if you think of a better solution for this. 